### PR TITLE
Changed include path for X11 and extensions.

### DIFF
--- a/cmake/FindX11.cmake
+++ b/cmake/FindX11.cmake
@@ -28,7 +28,7 @@
 # limitations under the License.
 #=============================================================================
 
-find_path(X11_INCLUDE_DIR NAMES Xlib.h
+find_path(X11_INCLUDE_DIR NAMES X11/Xlib.h
           PATH_SUFFIXES X11
           DOC "The X11 include directory"
 )

--- a/cmake/FindXKBFile.cmake
+++ b/cmake/FindXKBFile.cmake
@@ -28,7 +28,7 @@
 # limitations under the License.
 #=============================================================================
 
-find_path(XKBFILE_INCLUDE_DIR NAMES XKBfile.h
+find_path(XKBFILE_INCLUDE_DIR NAMES X11/extensions/XKBfile.h
           PATH_SUFFIXES X11/extensions
           DOC "The XKBFile include directory"
 )

--- a/cmake/FindXShm.cmake
+++ b/cmake/FindXShm.cmake
@@ -28,7 +28,7 @@
 # limitations under the License.
 #=============================================================================
 
-find_path(XSHM_INCLUDE_DIR NAMES XShm.h
+find_path(XSHM_INCLUDE_DIR NAMES X11/extensions/XShm.h
           PATH_SUFFIXES X11/extensions
           DOC "The XShm include directory"
 )

--- a/cmake/FindXTest.cmake
+++ b/cmake/FindXTest.cmake
@@ -28,7 +28,7 @@
 # limitations under the License.
 #=============================================================================
 
-find_path(XTEST_INCLUDE_DIR NAMES XTest.h
+find_path(XTEST_INCLUDE_DIR NAMES X11/extensions/XTest.h
           PATH_SUFFIXES X11/extensions
           DOC "The XTest include directory"
 )

--- a/cmake/FindXcursor.cmake
+++ b/cmake/FindXcursor.cmake
@@ -28,7 +28,7 @@
 # limitations under the License.
 #=============================================================================
 
-find_path(XCURSOR_INCLUDE_DIR NAMES Xcursor.h
+find_path(XCURSOR_INCLUDE_DIR NAMES X11/Xcursor/Xcursor.h
           PATH_SUFFIXES X11/Xcursor
           DOC "The Xcursor include directory"
 )

--- a/cmake/FindXdamage.cmake
+++ b/cmake/FindXdamage.cmake
@@ -28,7 +28,7 @@
 # limitations under the License.
 #=============================================================================
 
-find_path(XDAMAGE_INCLUDE_DIR NAMES Xdamage.h
+find_path(XDAMAGE_INCLUDE_DIR NAMES X11/extensions/Xdamage.h
           PATH_SUFFIXES X11/extensions
           DOC "The Xdamage include directory"
 )

--- a/cmake/FindXext.cmake
+++ b/cmake/FindXext.cmake
@@ -28,7 +28,7 @@
 # limitations under the License.
 #=============================================================================
 
-find_path(XEXT_INCLUDE_DIR NAMES Xext.h
+find_path(XEXT_INCLUDE_DIR NAMES X11/extensions/Xext.h
           PATH_SUFFIXES X11/extensions
           DOC "The Xext include directory"
 )

--- a/cmake/FindXfixes.cmake
+++ b/cmake/FindXfixes.cmake
@@ -28,7 +28,7 @@
 # limitations under the License.
 #=============================================================================
 
-find_path(XFIXES_INCLUDE_DIR NAMES Xfixes.h
+find_path(XFIXES_INCLUDE_DIR NAMES X11/extensions/Xfixes.h
           PATH_SUFFIXES X11/extensions
           DOC "The Xfixes include directory"
 )

--- a/cmake/FindXinerama.cmake
+++ b/cmake/FindXinerama.cmake
@@ -28,7 +28,7 @@
 # limitations under the License.
 #=============================================================================
 
-find_path(XINERAMA_INCLUDE_DIR NAMES Xinerama.h
+find_path(XINERAMA_INCLUDE_DIR NAMES X11/extensions/Xinerama.h
           PATH_SUFFIXES X11/extensions
           DOC "The Xinerama include directory"
 )

--- a/cmake/FindXv.cmake
+++ b/cmake/FindXv.cmake
@@ -28,7 +28,7 @@
 # limitations under the License.
 #=============================================================================
 
-find_path(XV_INCLUDE_DIR NAMES Xv.h
+find_path(XV_INCLUDE_DIR NAMES X11/extensions/Xv.h
           PATH_SUFFIXES X11/extensions
           DOC "The Xv include directory"
 )


### PR DESCRIPTION
X11 and X11/extensions should not be part of X11 include path
if X11/xxx.h or X11/extensions/xxx.h is used in source files.

This can cause Problems if X11 headers are not located in standard include locations like /usr/include.
